### PR TITLE
support 03-24

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "VaporStencil",
     dependencies: [
-        .Package(url: "https://github.com/kylef/Stencil.git", majorVersion: 0),
+        .Package(url: "https://github.com/ratranqu/Stencil.git", majorVersion: 0),
         .Package(url: "https://github.com/qutheory/vapor.git", majorVersion: 0)
     ]
 )

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -2,10 +2,6 @@ import Stencil
 import PathKit
 import Vapor
 
-extension Application {
-  var resourcesDir: String { return workDir + "Resources/" }
-  var viewsDir: String { return resourcesDir + "Views/" }
-}
 
 public class Provider: Vapor.Provider {
   public static var renderer: StencilRenderer?

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -9,7 +9,7 @@ public class Provider: Vapor.Provider {
   public func boot(application: Application) {
     let renderer: StencilRenderer
     
-    if let r = Provider.renderer {
+    if let r = renderer {
       renderer = r
     } else {
       renderer = StencilRenderer(

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -4,9 +4,9 @@ import Vapor
 
 
 public class Provider: Vapor.Provider {
-  public static var renderer: StencilRenderer?
+  public var renderer: StencilRenderer?
   
-  public static func boot(application: Application) {
+  public func boot(application: Application) {
     let renderer: StencilRenderer
     
     if let r = Provider.renderer {

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -2,10 +2,27 @@ import Stencil
 import PathKit
 import Vapor
 
+extension Application {
+  var resourcesDir: String { return workDir + "Resources/" }
+  var viewsDir: String { return resourcesDir + "Views/" }
+}
+
 public class Provider: Vapor.Provider {
-    public static func boot(application: Application) {
-        View.renderers[".stencil"] = StencilRenderer( namespace: Namespace(),
-                                                      templateLoader: TemplateLoader(paths: [Path(application.workDir + "Resources/")]))
+  public static var renderer: StencilRenderer?
+  
+  public static func boot(application: Application) {
+    let renderer: StencilRenderer
+    
+    if let r = Provider.renderer {
+      renderer = r
+    } else {
+      renderer = StencilRenderer(
+        namespace: Namespace(),
+        templateLoader: TemplateLoader(paths: [Path(application.viewsDir)])
+      )
     }
     
+    View.renderers[".stencil"] = renderer
+  }
+  
 }

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -1,10 +1,11 @@
+import Stencil
+import PathKit
 import Vapor
 
 public class Provider: Vapor.Provider {
-	public static let renderer = StencilRenderer()
-
-	public static func boot(application: Application) {
-		View.renderers[".stencil"] = self.renderer
-	}
-
+    public static func boot(application: Application) {
+        View.renderers[".stencil"] = StencilRenderer( namespace: Namespace(),
+                                                      templateLoader: TemplateLoader(paths: [Path(application.workDir + "Resources/")]))
+    }
+    
 }

--- a/Sources/StencilRenderer.swift
+++ b/Sources/StencilRenderer.swift
@@ -1,22 +1,21 @@
 import Stencil
-import PathKit
 import Vapor
 
 public class StencilRenderer: RenderDriver {
-	public let namespace: Namespace
-	public let templateLoader: TemplateLoader
-
-	public init(namespace: Namespace = Namespace(), templateLoader: TemplateLoader? = nil) {
-		self.namespace = namespace
-		self.templateLoader = templateLoader ?? TemplateLoader(paths: [Path(View.resourceDir)])
-	}
-
-	public func render(template template: String, context: [String: Any]) throws -> String {
-		let c = Context(dictionary: context)
-		c["loader"] = self.templateLoader
-
-		let template = Template(templateString: template)
-		return try template.render(c, namespace: self.namespace)
-	}
-
+    public let namespace: Namespace
+    public let templateLoader: TemplateLoader
+    
+    public init(namespace: Namespace = Namespace(), templateLoader: TemplateLoader) {
+        self.namespace = namespace
+        self.templateLoader = templateLoader
+    }
+    
+    public func render(template template: String, context: [String: Any]) throws -> String {
+        let c = Context(dictionary: context, namespace: self.namespace)
+        c["loader"] = self.templateLoader
+        
+        let template = Template(templateString: template)
+        return try template.render(c)
+    }
+    
 }


### PR DESCRIPTION
Hi,

I fixed to work with Vapour 0.4.1 and added support for swift 3.0 (DEVELOPMENT-SNAPSHOT-2016-03-24-a) using macros checking the swift version, so should work both with 2.2 and (current) 3.0 dev.

Swift 3.0 related changes are mostly about keeping up with the swift-3-api-guidelines induced changes.

As I've also changed Package.swift to point to the relevant Stencil release, you may want (depending on timing) to keep my changes to that file or not.